### PR TITLE
Add organization membership support

### DIFF
--- a/src/main/java/org/sonarsource/auth/github/GitHubIdentityProvider.java
+++ b/src/main/java/org/sonarsource/auth/github/GitHubIdentityProvider.java
@@ -85,7 +85,7 @@ public class GitHubIdentityProvider implements OAuth2IdentityProvider {
   public void init(InitContext context) {
     String state = context.generateCsrfState();
     OAuthService scribe = prepareScribe(context)
-      .scope("user:email")
+      .scope("user:email,read:org")
       .state(state)
       .build();
     String url = scribe.getAuthorizationUrl(EMPTY_TOKEN);

--- a/src/main/java/org/sonarsource/auth/github/GitHubIdentityProvider.java
+++ b/src/main/java/org/sonarsource/auth/github/GitHubIdentityProvider.java
@@ -30,7 +30,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.sonar.api.server.ServerSide;
 import org.sonar.api.server.authentication.Display;
 import org.sonar.api.server.authentication.OAuth2IdentityProvider;
-import org.sonar.api.server.authentication.UnauthorizedException;
 import org.sonar.api.server.authentication.UserIdentity;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
@@ -115,7 +114,7 @@ public class GitHubIdentityProvider implements OAuth2IdentityProvider {
     GsonUser gsonUser = GsonUser.parse(userResponseBody);
 
     if (settings.organization() != null && !isOrganizationMember(scribe, accessToken, settings.organization(), gsonUser.getLogin())) {
-      throw new UnauthorizedException(format("'%s' must be a member of the '%s' organization.", gsonUser, settings.organization()));
+      throw new IllegalStateException(format("'%s' must be a member of the '%s' organization.", gsonUser, settings.organization()));
     }
 
     UserIdentity userIdentity = UserIdentity.builder()

--- a/src/main/java/org/sonarsource/auth/github/GitHubIdentityProvider.java
+++ b/src/main/java/org/sonarsource/auth/github/GitHubIdentityProvider.java
@@ -113,7 +113,7 @@ public class GitHubIdentityProvider implements OAuth2IdentityProvider {
     LOGGER.trace("User response received : %s", userResponseBody);
     GsonUser gsonUser = GsonUser.parse(userResponseBody);
 
-    if (settings.organization() != null && !isOrganizationMember(scribe, accessToken, settings.organization(), gsonUser.getLogin())) {
+    if (settings.organization() != null && !isOrganizationMember(accessToken, settings.organization(), gsonUser.getLogin())) {
       throw new IllegalStateException(format("'%s' must be a member of the '%s' organization.", gsonUser, settings.organization()));
     }
 
@@ -131,8 +131,13 @@ public class GitHubIdentityProvider implements OAuth2IdentityProvider {
    * Check to see that login is member of organization.
    * https://developer.github.com/v3/orgs/members/#response-if-requester-is-an-organization-member-and-user-is-a-member
    */
-  private static Boolean isOrganizationMember(OAuthService scribe, Token accessToken, String organization, String login) {
+  private Boolean isOrganizationMember(Token accessToken, String organization, String login) {
     String requestUrl = format("https://api.github.com/orgs/%s/members/%s", organization, login);
+    OAuthService scribe = new ServiceBuilder()
+      .provider(GitHubApi.class)
+      .apiKey(settings.clientId())
+      .apiSecret(settings.clientSecret())
+      .build();
     OAuthRequest request = new OAuthRequest(Verb.GET, requestUrl, scribe);
     scribe.signRequest(accessToken, request);
 

--- a/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
+++ b/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
@@ -38,6 +38,7 @@ public class GitHubSettings {
   public static final String CLIENT_SECRET = "sonar.auth.github.clientSecret.secured";
   public static final String ENABLED = "sonar.auth.github.enabled";
   public static final String ALLOW_USERS_TO_SIGN_UP = "sonar.auth.github.allowUsersToSignUp";
+  public static final String ORGANIZATION = "sonar.auth.github.organization";
 
   public static final String LOGIN_STRATEGY = "sonar.auth.github.loginStrategy";
   public static final String LOGIN_STRATEGY_UNIQUE = "Unique";
@@ -120,6 +121,12 @@ public class GitHubSettings {
         .defaultValue(LOGIN_STRATEGY_DEFAULT_VALUE)
         .options(LOGIN_STRATEGY_UNIQUE, LOGIN_STRATEGY_PROVIDER_ID)
         .index(5)
+      PropertyDefinition.builder(ORGANIZATION)
+        .name("Organization")
+        .description("Only members of this organization will be able to authenticate to the server.")
+        .category(CATEGORY)
+        .subCategory(SUBCATEGORY)
+        .index(6)
         .build()
       );
   }

--- a/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
+++ b/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
@@ -76,6 +76,10 @@ public class GitHubSettings {
     return settings.getString(LOGIN_STRATEGY);
   }
 
+  public String organization() {
+    return settings.getString(ORGANIZATION);
+  }
+
   public static List<PropertyDefinition> definitions() {
     return Arrays.asList(
       PropertyDefinition.builder(ENABLED)
@@ -121,6 +125,7 @@ public class GitHubSettings {
         .defaultValue(LOGIN_STRATEGY_DEFAULT_VALUE)
         .options(LOGIN_STRATEGY_UNIQUE, LOGIN_STRATEGY_PROVIDER_ID)
         .index(5)
+        .build(),
       PropertyDefinition.builder(ORGANIZATION)
         .name("Organization")
         .description("Only members of this organization will be able to authenticate to the server.")

--- a/src/test/java/org/sonarsource/auth/github/AuthGitHubPluginTest.java
+++ b/src/test/java/org/sonarsource/auth/github/AuthGitHubPluginTest.java
@@ -29,6 +29,6 @@ public class AuthGitHubPluginTest {
 
   @Test
   public void test_extensions() throws Exception {
-    assertThat(underTest.getExtensions()).hasSize(7);
+    assertThat(underTest.getExtensions()).hasSize(8);
   }
 }

--- a/src/test/java/org/sonarsource/auth/github/GitHubIdentityProviderTest.java
+++ b/src/test/java/org/sonarsource/auth/github/GitHubIdentityProviderTest.java
@@ -71,7 +71,7 @@ public class GitHubIdentityProviderTest {
 
     underTest.init(context);
 
-    verify(context).redirectTo("https://github.com/login/oauth/authorize?client_id=id&redirect_uri=http%3A%2F%2Flocalhost%2Fcallback&scope=user%3Aemail&state=state");
+    verify(context).redirectTo("https://github.com/login/oauth/authorize?client_id=id&redirect_uri=http%3A%2F%2Flocalhost%2Fcallback&scope=user%3Aemail%2Cread%3Aorg&state=state");
   }
 
   @Test

--- a/src/test/java/org/sonarsource/auth/github/GitHubSettingsTest.java
+++ b/src/test/java/org/sonarsource/auth/github/GitHubSettingsTest.java
@@ -104,6 +104,6 @@ public class GitHubSettingsTest {
 
   @Test
   public void definitions() throws Exception {
-    assertThat(GitHubSettings.definitions()).hasSize(5);
+    assertThat(GitHubSettings.definitions()).hasSize(6);
   }
 }

--- a/src/test/java/org/sonarsource/auth/github/GitHubSettingsTest.java
+++ b/src/test/java/org/sonarsource/auth/github/GitHubSettingsTest.java
@@ -103,6 +103,16 @@ public class GitHubSettingsTest {
   }
 
   @Test
+  public void organization() throws Exception {
+    settings.setProperty("sonar.auth.github.organization", "example");
+    assertThat(underTest.organization()).isEqualTo("example");
+
+    // default value
+    settings.setProperty("sonar.auth.github.organization", (String) null);
+    assertThat(underTest.organization()).isNull();
+  }
+
+  @Test
   public void definitions() throws Exception {
     assertThat(GitHubSettings.definitions()).hasSize(6);
   }


### PR DESCRIPTION
Support authenticating users by organization membership.  This requires expanding the scope to include `read:org` for GitHub users that do not publicize their organization membership.
