### PR TITLE
Add organizations membership support

### DIFF
--- a/src/main/java/org/sonarsource/auth/github/GitHubIdentityProvider.java
+++ b/src/main/java/org/sonarsource/auth/github/GitHubIdentityProvider.java
@@ -111,14 +111,14 @@ public class GitHubIdentityProvider implements OAuth2IdentityProvider {
     OAuthRequest userRequest = new OAuthRequest(Verb.GET, settings.apiURL() + "user", scribe);
     scribe.signRequest(accessToken, userRequest);
 
-    UserIdentity userIdentity = userIdentityFactory.create(getUser(scribe, accessToken),
-      settings.syncGroups() ? getTeams(scribe, accessToken) : null);
-
-    if (isOrganizationMembershipRequired() && !isOrganizationsMember(accessToken, userIdentity.getLogin())) {
+    GsonUser user = getUser(scribe, accessToken);
+    if (isOrganizationMembershipRequired() && !isOrganizationsMember(accessToken, user.getLogin())) {
       throw new IllegalStateException(format("'%s' must be a member of at least one organization: '%s'",
-        userIdentity.getLogin(), Joiner.on(", ").join(settings.organizations())));
+        user.getLogin(), Joiner.on(", ").join(settings.organizations())));
     }
 
+    UserIdentity userIdentity = userIdentityFactory.create(user,
+      settings.syncGroups() ? getTeams(scribe, accessToken) : null);
     context.authenticate(userIdentity);
     context.redirectToRequestedPage();
   }

--- a/src/main/java/org/sonarsource/auth/github/GitHubIdentityProvider.java
+++ b/src/main/java/org/sonarsource/auth/github/GitHubIdentityProvider.java
@@ -86,11 +86,15 @@ public class GitHubIdentityProvider implements OAuth2IdentityProvider {
   public void init(InitContext context) {
     String state = context.generateCsrfState();
     OAuthService scribe = newScribeBuilder(context)
-      .scope(settings.syncGroups() ? "user:email,read:org" : "user:email")
+      .scope(getScope())
       .state(state)
       .build();
     String url = scribe.getAuthorizationUrl(EMPTY_TOKEN);
     context.redirectTo(url);
+  }
+
+  public String getScope() {
+    return (settings.syncGroups() || !settings.organizations().isEmpty()) ? "user:email,read:org" : "user:email";
   }
 
   @Override

--- a/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
+++ b/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
@@ -50,6 +50,8 @@ public class GitHubSettings {
   public static final String LOGIN_STRATEGY_PROVIDER_ID = "Same as GitHub login";
   public static final String LOGIN_STRATEGY_DEFAULT_VALUE = LOGIN_STRATEGY_UNIQUE;
 
+  public static final String ORGANIZATIONS = "sonar.auth.github.organizations";
+
   public static final String CATEGORY = "github";
   public static final String SUBCATEGORY = "authentication";
 
@@ -92,6 +94,8 @@ public class GitHubSettings {
   public String apiURL() {
     return urlWithEndingSlash(settings.getString(API_URL));
   }
+
+  public String organizations() { return settings.getString(ORGANIZATIONS); }
 
   private static String urlWithEndingSlash(@Nullable String url) {
     if (url != null && !url.endsWith("/")) {
@@ -173,6 +177,14 @@ public class GitHubSettings {
         .subCategory(SUBCATEGORY)
         .type(STRING)
         .defaultValue(valueOf("https://github.com/"))
+        .index(index++)
+        .build(),
+      PropertyDefinition.builder(ORGANIZATIONS)
+        .name("Organizations")
+        .description("Only members of these organizations will be able to authenticate to the server. " +
+          "Specify multiple organizations as a comma separated list.")
+        .category(CATEGORY)
+        .subCategory(SUBCATEGORY)
         .index(index++)
         .build()
       );

--- a/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
+++ b/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
@@ -98,7 +98,7 @@ public class GitHubSettings {
 
   public List<String> organizations() {
     String setting = settings.getString(ORGANIZATIONS);
-    return (isNullOrEmpty(setting)) ? new ArrayList<String>() : Arrays.asList(setting.split("\\s*,\\s*"));
+    return isNullOrEmpty(setting) ? new ArrayList<String>() : Arrays.asList(setting.split("\\s*,\\s*"));
   }
 
   private static String urlWithEndingSlash(@Nullable String url) {

--- a/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
+++ b/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
@@ -19,6 +19,7 @@
  */
 package org.sonarsource.auth.github;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -95,7 +96,10 @@ public class GitHubSettings {
     return urlWithEndingSlash(settings.getString(API_URL));
   }
 
-  public String organizations() { return settings.getString(ORGANIZATIONS); }
+  public List<String> organizations() {
+    String setting = settings.getString(ORGANIZATIONS);
+    return (isNullOrEmpty(setting)) ? new ArrayList<String>() : Arrays.asList(setting.split("\\s*,\\s*"));
+  }
 
   private static String urlWithEndingSlash(@Nullable String url) {
     if (url != null && !url.endsWith("/")) {

--- a/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
+++ b/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
@@ -186,7 +186,8 @@ public class GitHubSettings {
       PropertyDefinition.builder(ORGANIZATIONS)
         .name("Organizations")
         .description("Only members of these organizations will be able to authenticate to the server. " +
-          "Specify multiple organizations as a comma separated list.")
+          "Specify multiple organizations as a comma separated list. " +
+          "If a user is a member of any of the organizations listed they will be authenticated.")
         .category(CATEGORY)
         .subCategory(SUBCATEGORY)
         .index(index++)

--- a/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
+++ b/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
@@ -19,7 +19,6 @@
  */
 package org.sonarsource.auth.github;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -96,10 +95,7 @@ public class GitHubSettings {
     return urlWithEndingSlash(settings.getString(API_URL));
   }
 
-  public List<String> organizations() {
-    String setting = settings.getString(ORGANIZATIONS);
-    return isNullOrEmpty(setting) ? new ArrayList<String>() : Arrays.asList(setting.split("\\s*,\\s*"));
-  }
+  public String[] organizations() { return settings.getStringArray(ORGANIZATIONS); }
 
   private static String urlWithEndingSlash(@Nullable String url) {
     if (url != null && !url.endsWith("/")) {
@@ -186,8 +182,8 @@ public class GitHubSettings {
       PropertyDefinition.builder(ORGANIZATIONS)
         .name("Organizations")
         .description("Only members of these organizations will be able to authenticate to the server. " +
-          "Specify multiple organizations as a comma separated list. " +
           "If a user is a member of any of the organizations listed they will be authenticated.")
+        .multiValues(true)
         .category(CATEGORY)
         .subCategory(SUBCATEGORY)
         .index(index++)

--- a/src/test/java/org/sonarsource/auth/github/AuthGitHubPluginTest.java
+++ b/src/test/java/org/sonarsource/auth/github/AuthGitHubPluginTest.java
@@ -29,6 +29,6 @@ public class AuthGitHubPluginTest {
 
   @Test
   public void test_extensions() throws Exception {
-    assertThat(underTest.getExtensions()).hasSize(12);
+    assertThat(underTest.getExtensions()).hasSize(13);
   }
 }

--- a/src/test/java/org/sonarsource/auth/github/GitHubIdentityProviderTest.java
+++ b/src/test/java/org/sonarsource/auth/github/GitHubIdentityProviderTest.java
@@ -90,6 +90,20 @@ public class GitHubIdentityProviderTest {
   }
 
   @Test
+  public void init_when_organizations() throws Exception {
+    setSettings(true);
+    settings.setProperty("sonar.auth.github.organizations", "example");
+    settings.setProperty("sonar.auth.github.webUrl", "https://github.com/");
+    OAuth2IdentityProvider.InitContext context = mock(OAuth2IdentityProvider.InitContext.class);
+    when(context.generateCsrfState()).thenReturn("state");
+    when(context.getCallbackUrl()).thenReturn("http://localhost/callback");
+
+    underTest.init(context);
+
+    verify(context).redirectTo("https://github.com/login/oauth/authorize?client_id=id&redirect_uri=http%3A%2F%2Flocalhost%2Fcallback&scope=user%3Aemail%2Cread%3Aorg&state=state");
+  }
+
+  @Test
   public void fail_to_init_when_disabled() throws Exception {
     setSettings(false);
     OAuth2IdentityProvider.InitContext context = mock(OAuth2IdentityProvider.InitContext.class);
@@ -118,6 +132,22 @@ public class GitHubIdentityProviderTest {
     settings.setProperty("sonar.auth.github.groupsSync", true);
     settings.setProperty("sonar.auth.github.organizations", "example");
     assertThat(underTest.getScope()).isEqualTo("user:email,read:org");
+  }
+
+  @Test
+  public void organization_membership_required() {
+    setSettings(true);
+    settings.setProperty("sonar.auth.github.organizations", "example");
+    assertThat(underTest.isOrganizationMembershipRequired()).isTrue();
+    settings.setProperty("sonar.auth.github.organizations", "example0, example1");
+    assertThat(underTest.isOrganizationMembershipRequired()).isTrue();
+  }
+
+  @Test
+  public void organization_membership_not_required() {
+    setSettings(true);
+    settings.setProperty("sonar.auth.github.organizations", "");
+    assertThat(underTest.isOrganizationMembershipRequired()).isFalse();
   }
 
   private void setSettings(boolean enabled) {

--- a/src/test/java/org/sonarsource/auth/github/GitHubIdentityProviderTest.java
+++ b/src/test/java/org/sonarsource/auth/github/GitHubIdentityProviderTest.java
@@ -99,6 +99,27 @@ public class GitHubIdentityProviderTest {
     underTest.init(context);
   }
 
+  @Test
+  public void scope_includes_org_when_necessary() {
+    setSettings(false);
+
+    settings.setProperty("sonar.auth.github.groupsSync", false);
+    settings.setProperty("sonar.auth.github.organizations", "");
+    assertThat(underTest.getScope()).isEqualTo("user:email");
+
+    settings.setProperty("sonar.auth.github.groupsSync", true);
+    settings.setProperty("sonar.auth.github.organizations", "");
+    assertThat(underTest.getScope()).isEqualTo("user:email,read:org");
+
+    settings.setProperty("sonar.auth.github.groupsSync", false);
+    settings.setProperty("sonar.auth.github.organizations", "example");
+    assertThat(underTest.getScope()).isEqualTo("user:email,read:org");
+
+    settings.setProperty("sonar.auth.github.groupsSync", true);
+    settings.setProperty("sonar.auth.github.organizations", "example");
+    assertThat(underTest.getScope()).isEqualTo("user:email,read:org");
+  }
+
   private void setSettings(boolean enabled) {
     if (enabled) {
       settings.setProperty("sonar.auth.github.clientId.secured", "id");

--- a/src/test/java/org/sonarsource/auth/github/GitHubSettingsTest.java
+++ b/src/test/java/org/sonarsource/auth/github/GitHubSettingsTest.java
@@ -19,6 +19,9 @@
  */
 package org.sonarsource.auth.github;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Test;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
@@ -129,9 +132,30 @@ public class GitHubSettingsTest {
   }
 
   @Test
-  public void return_organizations() {
-    settings.setProperty("sonar.auth.github.organizations", "example");
-    assertThat(underTest.organizations()).isEqualTo("example");
+  public void return_organizations_single() {
+    String setting = "example";
+    settings.setProperty("sonar.auth.github.organizations", setting);
+    List<String> expected = Arrays.asList(setting);
+    List<String> actual = underTest.organizations();
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void return_organizations_multiple() {
+    String setting = "example0,example1";
+    settings.setProperty("sonar.auth.github.organizations", setting);
+    List<String> expected = Arrays.asList(setting.split("\\s*,\\s*"));
+    List<String> actual = underTest.organizations();
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void return_organizations_empty_list() {
+    String setting = "";
+    settings.setProperty("sonar.auth.github.organizations", setting);
+    List<String> expected = new ArrayList<String>();
+    List<String> actual = underTest.organizations();
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test

--- a/src/test/java/org/sonarsource/auth/github/GitHubSettingsTest.java
+++ b/src/test/java/org/sonarsource/auth/github/GitHubSettingsTest.java
@@ -135,8 +135,8 @@ public class GitHubSettingsTest {
   public void return_organizations_single() {
     String setting = "example";
     settings.setProperty("sonar.auth.github.organizations", setting);
-    List<String> expected = Arrays.asList(setting);
-    List<String> actual = underTest.organizations();
+    String[] expected = new String[]{"example"};
+    String[] actual = underTest.organizations();
     assertThat(actual).isEqualTo(expected);
   }
 
@@ -144,17 +144,17 @@ public class GitHubSettingsTest {
   public void return_organizations_multiple() {
     String setting = "example0,example1";
     settings.setProperty("sonar.auth.github.organizations", setting);
-    List<String> expected = Arrays.asList(setting.split("\\s*,\\s*"));
-    List<String> actual = underTest.organizations();
+    String[] expected = new String[]{"example0", "example1"};
+    String[] actual = underTest.organizations();
     assertThat(actual).isEqualTo(expected);
   }
 
   @Test
   public void return_organizations_empty_list() {
-    String setting = "";
+    String[] setting = null;
     settings.setProperty("sonar.auth.github.organizations", setting);
-    List<String> expected = new ArrayList<String>();
-    List<String> actual = underTest.organizations();
+    String[] expected = new String[]{};
+    String[] actual = underTest.organizations();
     assertThat(actual).isEqualTo(expected);
   }
 

--- a/src/test/java/org/sonarsource/auth/github/GitHubSettingsTest.java
+++ b/src/test/java/org/sonarsource/auth/github/GitHubSettingsTest.java
@@ -129,7 +129,13 @@ public class GitHubSettingsTest {
   }
 
   @Test
+  public void return_organizations() {
+    settings.setProperty("sonar.auth.github.organizations", "example");
+    assertThat(underTest.organizations()).isEqualTo("example");
+  }
+
+  @Test
   public void definitions() {
-    assertThat(GitHubSettings.definitions()).hasSize(8);
+    assertThat(GitHubSettings.definitions()).hasSize(9);
   }
 }

--- a/src/test/java/org/sonarsource/auth/github/IntegrationTest.java
+++ b/src/test/java/org/sonarsource/auth/github/IntegrationTest.java
@@ -35,6 +35,7 @@ import org.junit.rules.ExpectedException;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
 import org.sonar.api.server.authentication.OAuth2IdentityProvider;
+import org.sonar.api.server.authentication.UnauthorizedException;
 import org.sonar.api.server.authentication.UserIdentity;
 
 import static java.lang.String.format;
@@ -190,7 +191,7 @@ public class IntegrationTest {
 
     HttpServletRequest request = newRequest("the-verifier-code");
     DumbCallbackContext callbackContext = new DumbCallbackContext(request);
-    expectedException.expect(IllegalStateException.class);
+    expectedException.expect(UnauthorizedException.class);
     expectedException.expectMessage("'octocat' must be a member of at least one organization: 'example'");
     underTest.callback(callbackContext);
   }
@@ -208,7 +209,7 @@ public class IntegrationTest {
 
     HttpServletRequest request = newRequest("the-verifier-code");
     DumbCallbackContext callbackContext = new DumbCallbackContext(request);
-    expectedException.expect(IllegalStateException.class);
+    expectedException.expect(UnauthorizedException.class);
     expectedException.expectMessage("'octocat' must be a member of at least one organization: 'example'");
     underTest.callback(callbackContext);
   }


### PR DESCRIPTION
Support conditional authentication by GitHub organization membership.
- A CSV list of organizations can be used to allow a member of _any_ of those organizations to authenticate
- `read:org` permissions are added to the GitHub OAuth screen so that members who do not publicize their memberships can still be authenticated
