### PR TITLE
Add all users also to group sonar-users.

### DIFF
--- a/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
+++ b/src/main/java/org/sonarsource/auth/github/GitHubSettings.java
@@ -41,6 +41,7 @@ public class GitHubSettings {
   private static final String ENABLED = "sonar.auth.github.enabled";
   private static final String ALLOW_USERS_TO_SIGN_UP = "sonar.auth.github.allowUsersToSignUp";
   private static final String GROUPS_SYNC = "sonar.auth.github.groupsSync";
+  private static final String DEFAULT_GROUP = "sonar.defaultGroup";
   private static final String API_URL = "sonar.auth.github.apiUrl";
   private static final String WEB_URL = "sonar.auth.github.webUrl";
 
@@ -82,6 +83,10 @@ public class GitHubSettings {
 
   public boolean syncGroups() {
     return settings.getBoolean(GROUPS_SYNC);
+  }
+
+  public String defaultGroup() {
+    return emptyIfNull(settings.getString(DEFAULT_GROUP));
   }
 
   @CheckForNull

--- a/src/main/java/org/sonarsource/auth/github/UserIdentityFactory.java
+++ b/src/main/java/org/sonarsource/auth/github/UserIdentityFactory.java
@@ -19,7 +19,9 @@
  */
 package org.sonarsource.auth.github;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.sonar.api.server.ServerSide;
@@ -37,6 +39,8 @@ public class UserIdentityFactory {
 
   private final GitHubSettings settings;
 
+  private static final String DEFAULT_GROUP = "sonar-users";
+
   public UserIdentityFactory(GitHubSettings settings) {
     this.settings = settings;
   }
@@ -47,11 +51,15 @@ public class UserIdentityFactory {
       .setLogin(generateLogin(user))
       .setName(generateName(user))
       .setEmail(email);
+    Set<String> groups = new HashSet<>();
+    groups.add(DEFAULT_GROUP);
     if (teams != null) {
-      builder.setGroups(teams.stream()
-        .map(team -> team.getOrganizationId() + "/" + team.getId())
-        .collect(Collectors.toSet()));
+        groups.addAll(
+                teams.stream()
+                    .map(team -> team.getOrganizationId() + "/" + team.getId())
+                    .collect(Collectors.toSet()));
     }
+    builder.setGroups(groups);
     return builder.build();
   }
 

--- a/src/main/java/org/sonarsource/auth/github/UserIdentityFactory.java
+++ b/src/main/java/org/sonarsource/auth/github/UserIdentityFactory.java
@@ -39,8 +39,6 @@ public class UserIdentityFactory {
 
   private final GitHubSettings settings;
 
-  private static final String DEFAULT_GROUP = "sonar-users";
-
   public UserIdentityFactory(GitHubSettings settings) {
     this.settings = settings;
   }
@@ -52,7 +50,7 @@ public class UserIdentityFactory {
       .setName(generateName(user))
       .setEmail(email);
     Set<String> groups = new HashSet<>();
-    groups.add(DEFAULT_GROUP);
+    groups.add(settings.defaultGroup());
     if (teams != null) {
         groups.addAll(
                 teams.stream()

--- a/src/test/java/org/sonarsource/auth/github/IntegrationTest.java
+++ b/src/test/java/org/sonarsource/auth/github/IntegrationTest.java
@@ -213,7 +213,8 @@ public class IntegrationTest {
     DumbCallbackContext callbackContext = new DumbCallbackContext(request);
     underTest.callback(callbackContext);
 
-    assertThat(callbackContext.userIdentity.getGroups()).containsOnly("SonarSource/developers");
+    assertThat(callbackContext.userIdentity.getGroups()).contains("SonarSource/developers");
+    assertThat(callbackContext.userIdentity.getGroups()).contains("sonar-users");
   }
 
   @Test

--- a/src/test/java/org/sonarsource/auth/github/IntegrationTest.java
+++ b/src/test/java/org/sonarsource/auth/github/IntegrationTest.java
@@ -64,6 +64,7 @@ public class IntegrationTest {
     settings.setProperty("sonar.auth.github.enabled", true);
     settings.setProperty("sonar.auth.github.apiUrl", format("http://%s:%d", github.getHostName(), github.getPort()));
     settings.setProperty("sonar.auth.github.webUrl", format("http://%s:%d", github.getHostName(), github.getPort()));
+    settings.setProperty("sonar.defaultGroup", "sonar-users");
   }
 
   /**

--- a/src/test/java/org/sonarsource/auth/github/UserIdentityFactoryTest.java
+++ b/src/test/java/org/sonarsource/auth/github/UserIdentityFactoryTest.java
@@ -69,7 +69,8 @@ public class UserIdentityFactoryTest {
     );
     settings.setProperty(GitHubSettings.LOGIN_STRATEGY, GitHubSettings.LOGIN_STRATEGY_PROVIDER_ID);
     UserIdentity identity = underTest.create(gson, null, teams);
-    assertThat(identity.getGroups()).containsOnly("SonarSource/developers");
+      assertThat(identity.getGroups()).contains("sonar-users");
+      assertThat(identity.getGroups()).contains("SonarSource/developers");
   }
 
   @Test

--- a/src/test/java/org/sonarsource/auth/github/UserIdentityFactoryTest.java
+++ b/src/test/java/org/sonarsource/auth/github/UserIdentityFactoryTest.java
@@ -21,6 +21,8 @@ package org.sonarsource.auth.github;
 
 import java.util.Arrays;
 import java.util.List;
+
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -37,6 +39,11 @@ public class UserIdentityFactoryTest {
 
   Settings settings = new Settings(new PropertyDefinitions(GitHubSettings.definitions()));
   UserIdentityFactory underTest = new UserIdentityFactory(new GitHubSettings(settings));
+
+  @Before
+  public void setUp() {
+      settings.setProperty("sonar.defaultGroup", "sonar-users");
+  }
 
   /**
    * Keep the same login as at GitHub
@@ -72,6 +79,19 @@ public class UserIdentityFactoryTest {
       assertThat(identity.getGroups()).contains("sonar-users");
       assertThat(identity.getGroups()).contains("SonarSource/developers");
   }
+
+    @Test
+    public void create_for_provider_strategy_with_teams_and_modified_sonar_default_group() {
+        GsonUser gson = new GsonUser("octocat", "monalisa octocat", "octocat@github.com");
+        List<GsonTeams.GsonTeam> teams = Arrays.asList(
+                new GsonTeams.GsonTeam("developers", new GsonTeams.GsonOrganization("SonarSource"))
+        );
+        settings.setProperty(GitHubSettings.LOGIN_STRATEGY, GitHubSettings.LOGIN_STRATEGY_PROVIDER_ID);
+        settings.setProperty("sonar.defaultGroup", "my-custom-group");
+        UserIdentity identity = underTest.create(gson, null, teams);
+        assertThat(identity.getGroups()).contains("my-custom-group");
+        assertThat(identity.getGroups()).contains("SonarSource/developers");
+    }
 
   @Test
   public void create_for_unique_login_strategy() {


### PR DESCRIPTION
This pull request will add every user that is authenticated via Github also to the group `sonar-users`. This is based on this claim inside Sonarqube: 
>Any new users created will automatically join this group.

I would highly appreciate any feedback. Maybe there is a good reason this was not implemented before.  