### PR TITLE
Update docs to reflect correct callback URI

### DIFF
--- a/src/main/resources/org/sonar/l10n/authgithub.properties
+++ b/src/main/resources/org/sonar/l10n/authgithub.properties
@@ -1,5 +1,5 @@
 property.category.github=GitHub
 property.category.github.authentication=Authentication
-property.category.github.authentication.description=In order to enable GitHub authentication:<ul><li>SonarQube must be publicly accessible through HTTPS only</li><li>The property 'sonar.core.serverBaseURL' must be set to this public HTTPS URL</li><li>In your GitHub profile, you need to create a Developer Application for which the 'Authorization callback URL' must be set to <code>'&lt;value_of_sonar.core.serverBaseURL_property&gt;/oauth2/callback'</code>.</li></ul>
+property.category.github.authentication.description=In order to enable GitHub authentication:<ul><li>SonarQube must be publicly accessible through HTTPS only</li><li>The property 'sonar.core.serverBaseURL' must be set to this public HTTPS URL</li><li>In your GitHub profile, you need to create a Developer Application for which the 'Authorization callback URL' must be set to <code>'&lt;value_of_sonar.core.serverBaseURL_property&gt;/oauth/callback/github'</code>.</li></ul>
 
 


### PR DESCRIPTION
In the UI, the plugin states the callback URI should be `/oauth2/callback`

This should be (according to the tests) `/oauth/callback/github`, however.